### PR TITLE
Add Typescript typings + rework

### DIFF
--- a/API.md
+++ b/API.md
@@ -3,25 +3,25 @@ Mimos is a convenience class for retrieving mime information objects.
 
 ## Usage
 
-### `new Mimos([options])`
+### `new Mimos.Mimos([options])`
 
 Creates a new Mimos object where:
 
 - `[options]` - an option object the following keys
     - `[override]` - an object hash that is merged into the built in mime information specified [here](https://github.com/jshttp/mime-db). Each key value pair represents a single mime object. Each override value should follow this schema:
         - `key` - the key is the lower-cased correct mime-type. (Ex. "application/javascript").
-        - `value` - the value should an object following the specifications outlined [here](https://github.com/jshttp/mime-db#data-structure). Additional values include:
+        - `value` - the value should be an object following the specifications outlined [here](https://github.com/jshttp/mime-db#data-structure). Additional values include:
           - `type` - specify the `type` value of result objects, defaults to `key`. See the example below for more clarification.
           - `predicate` - method with signature `function(mime)` when this mime type is found in the database, this function will run. This allows you make customizations to `mime` based on developer criteria.
 
 ### `mimos.path(path)`
 
-Returns mime object where:
+Lookup file extension from path and return mime object, or `null` if not found, where:
 
 - `path` path to file including the file extension. Uses the `extension` values of the mime objects for lookup.
 
 ```js
-const mimos = new Mimos();
+const mimos = new Mimos.Mimos();
 const mime = mimos.path('/static/public/app.js');
 // mime
 /*
@@ -42,7 +42,7 @@ Returns mime object where:
 - `type` the content-type to find mime information about. Uses the `type` values of the mime objects for lookup.
 
 ```js
-const mimos = new Mimos();
+const mimos = new Mimos.Mimos();
 const mime = mimos.type('text/plain');
 // mime
 /*
@@ -90,7 +90,7 @@ const options = {
     }
 }
 
-const mimos = new Mimos(options);
+const mimos = new Mimos.Mimos(options);
 console.dir(mimos.path('./node_modules/mimos.module'));
 /*
 {

--- a/API.md
+++ b/API.md
@@ -16,7 +16,7 @@ Creates a new Mimos object where:
 
 ### `mimos.path(path)`
 
-Lookup file extension from path and return mime object, or `null` if not found, where:
+Lookup file extension from path and return mime object, or an empty object literal `{}` if not found, where:
 
 - `path` path to file including the file extension. Uses the `extension` values of the mime objects for lookup.
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,132 @@
+// Declare our own interface to mime-db data
+
+declare namespace MimeDb {
+
+    type MimeSource = 'iana' | 'apache' | 'nginx';
+
+    interface MimeEntry {
+
+        /**
+         * String with identifier for the source of the data.
+         */
+        source?: MimeSource;
+
+        /**
+         * Array of strings with possible lowercased file extensions, without the
+         * dot.
+         */
+        extensions?: ReadonlyArray<string>;
+
+        /**
+         * Boolean that indicates if the contents is likely to become smaller if
+         * gzip or similar compression is applied.
+         */
+        compressible?: boolean;
+
+        /**
+         * Charset for type.
+         */
+        charset?: string;
+    }
+}
+
+
+// Helpers
+
+type NoInfer<T> = [T][T extends any ? 0 : never];
+
+
+export interface MimosEntry {
+
+    /**
+     * String with the content-type.
+     */
+    type: string;
+
+    /**
+     * String with identifier for the source of the data.
+     */
+    source: MimeDb.MimeSource | 'mime-db' | 'mimos';
+
+    /**
+     * Array of strings with possible lowercased file extensions, without the
+     * dot.
+     */
+    extensions: ReadonlyArray<string>;
+
+    /**
+     * Boolean that indicates if the contents is likely to become smaller if
+     * gzip or similar compression is applied.
+     */
+    compressible: boolean;
+
+    /**
+     * Optional charset for type.
+     */
+    charset?: string;
+}
+
+export interface MimosDeclaration<P extends object = {}> extends MimeDb.MimeEntry {
+
+    /**
+     * The `type` value of result objects, defaults to `key`.
+     */
+    type?: string;
+
+    /**
+     * Method with signature `function(mime)`.
+     *
+     * When this mime type is found in the database, this function will run.
+     * This allows you make customizations to `mime` based on developer criteria.
+     */
+    predicate?: (mime: MimosEntry & P) => MimosEntry;
+}
+
+export interface MimosOptions<P extends object = {}> {
+
+    /**
+     * An object hash that is merged into the built-in mime information from
+     * {@link https://github.com/jshttp/mime-db}.
+     *
+     * Each key value pair represents a single mime object override.
+     *
+     * Each override entry should follow this schema:
+     *  * The key is the lower-cased correct mime-type. (Ex. "application/javascript").
+     *  * The value should be an object following the structure from
+     *    {@link https://github.com/jshttp/mime-db#data-structure} with additional
+     *    optional values:
+     *     * type - Specify the `type` value of result objects, defaults to `key`.
+     *     * predicate - Method that is called with mime entry on lookup, that
+     *       must return an entry. This allows you make customizations to `mime`
+     *       based on developer criteria.
+     */
+    override?: {
+        [type: string]: MimosDeclaration<P> & P;
+    };
+}
+
+export class Mimos<P extends object = {}> {
+
+    /**
+     * Create a Mimos object for mime lookups.
+     */
+    constructor(options?: MimosOptions<NoInfer<P>>);
+
+    /**
+     * Extract extension from file path and lookup mime information.
+     *
+     * @param path - Path to file
+     *
+     * @return Found mime object, or null if no match.
+     */
+    path(path: string): (Readonly<MimosEntry & Partial<P>>) | null;
+
+    /**
+     * Lookup mime information.
+     *
+     * @param type - The content-type to find mime information about.
+     *
+     * @return Mime object for provided type.
+    */
+    type(type: string): Readonly<MimosEntry & Partial<P>>;
+}

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -36,7 +36,7 @@ declare namespace MimeDb {
 type NoInfer<T> = [T][T extends any ? 0 : never];
 
 
-export interface MimosEntry {
+export class MimosEntry {
 
     /**
      * String with the content-type.
@@ -64,6 +64,8 @@ export interface MimosEntry {
      * Optional charset for type.
      */
     charset?: string;
+
+    private constructor();
 }
 
 export interface MimosDeclaration<P extends object = {}> extends MimeDb.MimeEntry {
@@ -117,9 +119,9 @@ export class Mimos<P extends object = {}> {
      *
      * @param path - Path to file
      *
-     * @return Found mime object, or null if no match.
+     * @return Found mime object, or {} if no match.
      */
-    path(path: string): (Readonly<MimosEntry & Partial<P>>) | null;
+    path(path: string): (Readonly<MimosEntry & Partial<P>>) | {};
 
     /**
      * Lookup mime information.

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,87 +6,142 @@ const Hoek = require('@hapi/hoek');
 const MimeDb = require('mime-db/db.json');          // Load JSON file to prevent loading or executing code
 
 
-const internals = {};
-
-
-internals.compressibleRx = /^text\/|\+json$|\+text$|\+xml$/;
-
-
-internals.compile = function (override) {
-
-    const db = Hoek.clone(MimeDb);
-    Hoek.merge(db, override, { nullOverride: true, mergeArrays: false });
-
-    const result = {
-        byType: db,
-        byExtension: {}
-    };
-
-    const keys = Object.keys(result.byType);
-    for (let i = 0; i < keys.length; ++i) {
-        const type = keys[i];
-        const mime = result.byType[type];
-        mime.type = mime.type || type;
-        mime.source = mime.source || 'mime-db';
-        mime.extensions = mime.extensions || [];
-        mime.compressible = (mime.compressible !== undefined ? mime.compressible : internals.compressibleRx.test(type));
-
-        Hoek.assert(!mime.predicate || typeof mime.predicate === 'function', 'predicate option must be a function');
-
-        for (let j = 0; j < mime.extensions.length; ++j) {
-            const ext = mime.extensions[j];
-            result.byExtension[ext] = mime;
-        }
-    }
-
-    return result;
+const internals = {
+    compressibleRx: /^text\/|\+json$|\+text$|\+xml$/
 };
 
 
-module.exports = class Mimos {
-    constructor(options) {
+internals.MimosEntry = class MimosEntry {
 
-        options = options || {};
-        const result = options.override ? internals.compile(options.override) : internals.base;
-        this._byType = result.byType;
-        this._byExtension = result.byExtension;
+    constructor(type, mime) {
+
+        this.type = type;
+        this.source = 'mime-db';
+        this.extensions = [];
+        this.compressible = undefined;
+
+        Object.assign(this, mime);
+
+        if (this.compressible === undefined) {
+            this.compressible = internals.compressibleRx.test(type);
+        }
+    }
+};
+
+
+internals.insertEntry = function (type, entry, db) {
+
+    db.byType.set(type, entry);
+    for (const ext of entry.extensions) {
+        db.byExtension.set(ext, entry);
+        if (ext.length > db.maxExtLength) {
+            db.maxExtLength = ext.length;
+        }
+    }
+};
+
+
+internals.compile = function (mimedb) {
+
+    const db = {
+        byType: new Map(),
+        byExtension: new Map(),
+        maxExtLength: 0
+    };
+
+    for (const type in mimedb) {
+        const entry = new internals.MimosEntry(type, mimedb[type]);
+        internals.insertEntry(type, entry, db);
+    }
+
+    return db;
+};
+
+
+internals.getTypePart = function (fulltype) {
+
+    const splitAt = fulltype.indexOf(';');
+    return splitAt === -1 ? fulltype : fulltype.slice(0, splitAt);
+};
+
+
+internals.applyPredicate = function (mime) {
+
+    if (mime && mime.predicate) {
+        return mime.predicate(Hoek.clone(mime));
+    }
+
+    return mime;
+};
+
+
+exports.Mimos = class Mimos {
+
+    #db = internals.base;
+
+    constructor(options = {}) {
+
+        if (options.override) {
+            Hoek.assert(typeof options.override === 'object', 'overrides option must be an object');
+
+            // Shallow clone db
+
+            this.#db = {
+                ...this.#db,
+                byType: new Map(this.#db.byType),
+                byExtension: new Map(this.#db.byExtension)
+            };
+
+            // Apply overrides
+
+            for (const type in options.override) {
+                const override = options.override[type];
+                Hoek.assert(!override.predicate || typeof override.predicate === 'function', 'predicate option must be a function');
+
+                const from = this.#db.byType.get(type);
+                const baseEntry = from ? Hoek.applyToDefaults(from, override) : override;
+
+                const entry = new internals.MimosEntry(type, baseEntry);
+                internals.insertEntry(type, entry, this.#db);
+            }
+        }
     }
 
     path(path) {
 
         const extension = Path.extname(path).slice(1).toLowerCase();
-        const mime = this._byExtension[extension] || {};
+        const mime = this.#db.byExtension.get(extension) || null;
 
-        if (mime.predicate) {
-            return mime.predicate(Hoek.clone(mime));
-        }
-
-        return mime;
+        return internals.applyPredicate(mime);
     }
 
     type(type) {
 
-        type = type.split(';', 1)[0].trim().toLowerCase();
-        let mime = this._byType[type];
-        if (!mime) {
-            mime = {
-                type,
-                source: 'mimos',
-                extensions: [],
-                compressible: internals.compressibleRx.test(type)
-            };
+        type = internals.getTypePart(type);
 
-            this._byType[type] = mime;
+        let mime = this.#db.byType.get(type);
+        if (!mime) {
+            // Retry with more expensive adaptations
+
+            type = type.trim().toLowerCase();
+            mime = this.#db.byType.get(type);
+        }
+
+        if (!mime) {
+            mime = new internals.MimosEntry(type, {
+                source: 'mimos'
+            });
+
+            // Cache the entry
+
+            internals.insertEntry(type, mime, this.#db);
+
             return mime;
         }
 
-        if (mime.predicate) {
-            return mime.predicate(Hoek.clone(mime));
-        }
-
-        return mime;
+        return internals.applyPredicate(mime);
     }
 };
 
 
-internals.base = internals.compile();       // Prevents an expensive copy on each constructor when no customization is needed
+internals.base = internals.compile(MimeDb);

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@ const internals = {
 };
 
 
-internals.MimosEntry = class MimosEntry {
+exports.MimosEntry = class {
 
     constructor(type, mime) {
 
@@ -50,7 +50,7 @@ internals.compile = function (mimedb) {
     };
 
     for (const type in mimedb) {
-        const entry = new internals.MimosEntry(type, mimedb[type]);
+        const entry = new exports.MimosEntry(type, mimedb[type]);
         internals.insertEntry(type, entry, db);
     }
 
@@ -67,7 +67,7 @@ internals.getTypePart = function (fulltype) {
 
 internals.applyPredicate = function (mime) {
 
-    if (mime && mime.predicate) {
+    if (mime.predicate) {
         return mime.predicate(Hoek.clone(mime));
     }
 
@@ -101,7 +101,7 @@ exports.Mimos = class Mimos {
                 const from = this.#db.byType.get(type);
                 const baseEntry = from ? Hoek.applyToDefaults(from, override) : override;
 
-                const entry = new internals.MimosEntry(type, baseEntry);
+                const entry = new exports.MimosEntry(type, baseEntry);
                 internals.insertEntry(type, entry, this.#db);
             }
         }
@@ -110,7 +110,7 @@ exports.Mimos = class Mimos {
     path(path) {
 
         const extension = Path.extname(path).slice(1).toLowerCase();
-        const mime = this.#db.byExtension.get(extension) || null;
+        const mime = this.#db.byExtension.get(extension) || {};
 
         return internals.applyPredicate(mime);
     }
@@ -128,7 +128,7 @@ exports.Mimos = class Mimos {
         }
 
         if (!mime) {
-            mime = new internals.MimosEntry(type, {
+            mime = new exports.MimosEntry(type, {
                 source: 'mimos'
             });
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@hapi/code": "8.x.x",
-    "@hapi/lab": "24.x.x",
+    "@hapi/lab": "^24.2.1",
     "typescript": "~4.0.7"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "5.0.0",
   "repository": "git://github.com/hapijs/mimos",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "files": [
     "lib"
   ],
@@ -18,10 +19,12 @@
   },
   "devDependencies": {
     "@hapi/code": "8.x.x",
-    "@hapi/lab": "24.x.x"
+    "@hapi/lab": "24.x.x",
+    "typescript": "^4.0.7"
   },
   "scripts": {
-    "test": "lab -m 5000 -t 100 -L -a @hapi/code"
+    "test": "lab -m 5000 -t 100 -L -a @hapi/code -Y",
+    "test-cov-html": "lab -a @hapi/code -r html -o coverage.html -L"
   },
   "license": "BSD-3-Clause"
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@hapi/code": "8.x.x",
     "@hapi/lab": "24.x.x",
-    "typescript": "^4.0.7"
+    "typescript": "~4.0.7"
   },
   "scripts": {
     "test": "lab -m 5000 -t 100 -L -a @hapi/code -Y",

--- a/test/index.js
+++ b/test/index.js
@@ -18,7 +18,7 @@ describe('Mimos', () => {
 
         it('returns the mime type from a file path', () => {
 
-            const mimos = new Mimos();
+            const mimos = new Mimos.Mimos();
 
             expect(mimos.path('/static/javascript/app.js')).equal({
                 source: 'iana',
@@ -29,18 +29,18 @@ describe('Mimos', () => {
             });
         });
 
-        it('returns empty object if a match can not be found', () => {
+        it('returns null if a match can not be found', () => {
 
-            const mimos = new Mimos();
+            const mimos = new Mimos.Mimos();
 
-            expect(mimos.path('/static/javascript')).to.equal({});
+            expect(mimos.path('/static/javascript')).to.be.null();
         });
 
         it('ignores extension upper case', () => {
 
             const lower = '/static/image/image.jpg';
             const upper = '/static/image/image.JPG';
-            const mimos = new Mimos();
+            const mimos = new Mimos.Mimos();
 
             expect(mimos.path(lower).type).to.equal(mimos.path(upper).type);
         });
@@ -50,7 +50,7 @@ describe('Mimos', () => {
 
         it('returns a found type', () => {
 
-            const mimos = new Mimos();
+            const mimos = new Mimos.Mimos();
 
             expect(mimos.type('text/plain')).to.equal({
                 source: 'iana',
@@ -60,9 +60,21 @@ describe('Mimos', () => {
             });
         });
 
+        it('returns a type when option is included', () => {
+
+            const mimos = new Mimos.Mimos();
+
+            expect(mimos.type('text/plain;charset=UTF-8')).to.equal({
+                source: 'iana',
+                compressible: true,
+                extensions: ['txt', 'text', 'conf', 'def', 'list', 'log', 'in', 'ini'],
+                type: 'text/plain'
+            });
+        });
+
         it('returns a missing type', () => {
 
-            const mimos = new Mimos();
+            const mimos = new Mimos.Mimos();
 
             expect(mimos.type('hapi/test')).to.equal({
                 source: 'mimos',
@@ -87,7 +99,7 @@ describe('Mimos', () => {
             }
         };
 
-        const mimos = new Mimos(dbOverwrite);
+        const mimos = new Mimos.Mimos(dbOverwrite);
         expect(mimos.type('node/module')).to.equal(nodeModule);
         expect(mimos.path('/node_modules/node/module.npm')).to.equal(nodeModule);
     });
@@ -107,7 +119,7 @@ describe('Mimos', () => {
             }
         };
 
-        const mimos = new Mimos(dbOverwrite);
+        const mimos = new Mimos.Mimos(dbOverwrite);
 
         expect(mimos.type('application/javascript')).to.equal(jsModule);
         expect(mimos.path('/static/js/app.js')).to.equal(jsModule);
@@ -131,7 +143,7 @@ describe('Mimos', () => {
             }
         };
 
-        const mimos = new Mimos(dbOverwrite);
+        const mimos = new Mimos.Mimos(dbOverwrite);
 
         const typeResult = mimos.type('application/javascript');
 
@@ -152,15 +164,23 @@ describe('Mimos', () => {
 
         expect(() => {
 
-            Mimos();
+            Mimos.Mimos();
         }).to.throw(/cannot be invoked without 'new'/g);
+    });
+
+    it('throws an error if override is not an object', () => {
+
+        expect(() => {
+
+            new Mimos.Mimos({ override: true });
+        }).to.throw('overrides option must be an object');
     });
 
     it('throws an error if the predicate option is not a functino', () => {
 
         expect(() => {
 
-            new Mimos({
+            new Mimos.Mimos({
                 override: {
                     'application/javascript': {
                         predicate: 'foo'

--- a/test/index.js
+++ b/test/index.js
@@ -29,11 +29,19 @@ describe('Mimos', () => {
             });
         });
 
-        it('returns null if a match can not be found', () => {
+        it('returns empty object if a match can not be found', () => {
 
             const mimos = new Mimos.Mimos();
 
-            expect(mimos.path('/static/javascript')).to.be.null();
+            expect(mimos.path('/static/javascript')).to.equal({});
+        });
+
+        it('can distinguish an empty return using instanceof', () => {
+
+            const mimos = new Mimos.Mimos();
+
+            expect(mimos.path('/static/javascript/app.js')).to.be.instanceof(Mimos.MimosEntry);
+            expect(mimos.path('/static/javascript')).to.not.be.instanceof(Mimos.MimosEntry);
         });
 
         it('ignores extension upper case', () => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -31,8 +31,17 @@ expect.error(mimos.type(true));
 
 // Mimos.path()
 
-expect.type<MimosEntry | null>(mimos.path('/my/file.html'));
-expect.type<MimosEntry & { custom?: boolean } | null>(new Mimos<{ custom: boolean }>().path('/my/file.html'))
+expect.type<MimosEntry | {}>(mimos.path('/my/file.html'));
+expect.type<MimosEntry & { custom?: boolean } | {}>(new Mimos<{ custom: boolean }>().path('/my/file.html'))
 
 expect.error(mimos.path());
 expect.error(mimos.path(new URL('file:///my/file.html')));
+
+// MimosEntry
+
+const entry = mimos.path('/my/file.html');
+if (entry instanceof MimosEntry) {
+    expect.type<MimosEntry>(entry);
+}
+
+//expect.error(new MimosEntry());       // Test is disabled due to Lab issue

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,38 @@
+import { Mimos, MimosEntry } from '..';
+import * as Lab from '@hapi/lab';
+
+const { expect } = Lab.types;
+
+
+const mimos = new Mimos();
+const predicate = (entry: MimosEntry) => entry;
+
+// constructor()
+
+expect.type<Mimos>(mimos);
+expect.type<Mimos>(new Mimos({ override: { 'test/html':  { compressible: false, predicate } }}));
+expect.type<Mimos>(new Mimos<{ custom: boolean }>({ override: { 'test/html': { compressible: false, predicate, custom: true } } }));
+
+expect.error(new Mimos({ unknown: true }));
+expect.error(new Mimos({ override: new Map() }));
+expect.error(new Mimos({ override: [{}] }));
+expect.error(new Mimos({ override: { 'test/html': { compressible: 0 } } }));
+expect.error(new Mimos({ override: { 'test/html': { predicate: () => true } } }));
+expect.error(new Mimos({ override: { 'test/html': { compressible: false, predicate, custom: true } } }));
+
+
+// Mimos.type()
+
+expect.type<MimosEntry>(mimos.type('text/html'));
+expect.type<MimosEntry & { custom?: boolean }>(new Mimos<{ custom: boolean }>().type('text/html'))
+
+expect.error(mimos.type());
+expect.error(mimos.type(true));
+
+// Mimos.path()
+
+expect.type<MimosEntry | null>(mimos.path('/my/file.html'));
+expect.type<MimosEntry & { custom?: boolean } | null>(new Mimos<{ custom: boolean }>().path('/my/file.html'))
+
+expect.error(mimos.path());
+expect.error(mimos.path(new URL('file:///my/file.html')));

--- a/test/index.ts
+++ b/test/index.ts
@@ -44,4 +44,4 @@ if (entry instanceof MimosEntry) {
     expect.type<MimosEntry>(entry);
 }
 
-//expect.error(new MimosEntry());       // Test is disabled due to Lab issue
+expect.error(new MimosEntry());


### PR DESCRIPTION
I wanted to add official typings to this module. In order to best do this, I **added 2 breaking changes**.

1. Move default export to `Mimos`. Ie. the class will now be found at `Mimos.Mimos()`. This is because Typescript has issues with default exports, and matches what was done in `Boom`.
2. Change `path()` to return `null` when no entry is found (instead of `{}`) – The `{}` return was a nonsensical API. Eg. declaring the return value with type `MimosEntry | {}`, makes it impossible to narrow it. With `null` it can be done with a simple `if (returnedValue)`.

While I was doing the changes, I found opportunities to speed it up. From the DB setup, the initial load took 10s of ms on my machine. I made several changes to speed it up:

1. Use `Map()` type instead of POJO for DB storage.
1. Rework compilation using knowledge of source data to avoid expensive `clone()` and `merge()` of mime-db data.
1. Use initially compiled DB as basis for overrides (instead of a full re-compile).

The behavior should match the current for common usage, with 2 exceptions for corner cases:

1. The `extensions` property is assigned with the value from the parsed json. If someone were to modify this mime-db object later, it can change the returned `extensions` value. *I don't believe this will be an issue in practice.*
1. The `path()` lookup might match another (valid) mime-type, if an override was provided for it, and multiple entries share an extension. *This is a rare case, that already relies on V8-specific behaviour. It probably works better, since overrides now **always** take precedence.*

For the ´type()` lookup, I made 2 speed-ups:

1. Faster type extraction from provided mime type (removing any options), using `indexOf()` and `slice()`.
1. Attempt a pre-check with a quick lookup, before doing the expensive `.trim().toLowerCase()`. This is a heuristic based optimisation, which will make the lookup slightly slower for an upper-cased type lookup, but make it a lot faster for the simple common case.

Since `mimos.type()` is called on most hapi server responses, this should make hapi slightly faster.