### PR TITLE
Support node v18 and drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -10,3 +10,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
-Copyright (c) 2014-2020, Sideway Inc, and project contributors  
-Copyright (c) 2014, Walmart.  
+Copyright (c) 2014-2022, Project contributors
+Copyright (c) 2014-2020, Sideway Inc
+Copyright (c) 2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/index.js
+++ b/lib/index.js
@@ -110,7 +110,7 @@ exports.Mimos = class Mimos {
     path(path) {
 
         const extension = Path.extname(path).slice(1).toLowerCase();
-        const mime = this.#db.byExtension.get(extension) || {};
+        const mime = this.#db.byExtension.get(extension) ?? {};
 
         return internals.applyPredicate(mime);
     }

--- a/package.json
+++ b/package.json
@@ -19,14 +19,15 @@
     ]
   },
   "dependencies": {
-    "@hapi/hoek": "9.x.x",
-    "mime-db": "1.x.x"
+    "@hapi/hoek": "^10.0.0",
+    "mime-db": "^1.52.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "^24.2.1",
-    "typescript": "~4.0.7"
+    "@hapi/lab": "^25.0.1",
+    "@types/node": "^17.0.31",
+    "typescript": "~4.6.4"
   },
   "scripts": {
     "test": "lab -m 5000 -t 100 -L -a @hapi/code -Y",

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let Mimos;
+
+    before(async () => {
+
+        Mimos = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(Mimos)).to.equal([
+            'Mimos',
+            'MimosEntry',
+            'default'
+        ]);
+    });
+});


### PR DESCRIPTION
 - Test on node v14+ and adopt some new syntax.
 - Update to node v18-compatible versions of hapi modules, update typescript.

If this looks good, this will go out as mimos v7.