### PR TITLE
fix: tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@hapi/hoek": "^11.0.2",
-    "mime-db": "^1.52.0"
+    "mime-db": "^1.53.0"
   },
   "devDependencies": {
     "@hapi/code": "^9.0.0",

--- a/test/esm.js
+++ b/test/esm.js
@@ -19,7 +19,7 @@ describe('import()', () => {
 
     it('exposes all methods and classes as named imports', () => {
 
-        expect(Object.keys(Mimos)).to.equal([
+        expect(Object.keys(Mimos).filter((k) => k !== 'module.exports')).to.equal([
             'Mimos',
             'MimosEntry',
             'default'

--- a/test/index.js
+++ b/test/index.js
@@ -25,7 +25,7 @@ describe('Mimos', () => {
                 charset: 'UTF-8',
                 compressible: true,
                 extensions: ['js', 'mjs'],
-                type: 'application/javascript'
+                type: 'text/javascript'
             });
         });
 


### PR DESCRIPTION
Apparently, the latest mime-db added `text/javascript` with the same extension (`.js`), and mimos' algorithm only supports one match (last one wins), luckily for us [it seems to be the official](https://stackoverflow.com/questions/21098865/text-javascript-vs-application-javascript), there are 47 extensions that have multiple mime types, I'm not sure whether we should do something about it.